### PR TITLE
Talon reset methods

### DIFF
--- a/src/main/kotlin/org/team5499/frc2019/Constants.kt
+++ b/src/main/kotlin/org/team5499/frc2019/Constants.kt
@@ -93,7 +93,7 @@ public object Constants {
         public const val LIFT_ZERO_SENSOR = 1
         public const val WRIST_MASTER = 4 // check this later
 
-        public const val INTAKE_MASTER = 27
+        public const val INTAKE = 27
 
         public const val GYRO_PORT = 10
     }

--- a/src/main/kotlin/org/team5499/frc2019/Constants.kt
+++ b/src/main/kotlin/org/team5499/frc2019/Constants.kt
@@ -9,7 +9,8 @@ public object Constants {
 
     object Input {
         public const val DRIVER_PORT = 0
-        public const val CODRIVER_PORT = 1
+        public const val CODRIVER_BUTTON_BOARD_PORT = 1
+        public const val CODRIVER_JOYSTICK_PORT = 2
 
         public const val JOYSTICK_DEADBAND = 0.02
         public const val TURN_MULT = 0.4
@@ -68,6 +69,13 @@ public object Constants {
         public const val INVERT_FIXED_AUX_PIDF = true
         public const val INVERT_ANGLE_AUX_PIDF = true
         public const val INVERT_TURN_AUX_PIDF = false
+    }
+
+    object Intake {
+        public const val INTAKE_SPEED = 0.6
+        public const val OUTTAKE_SPEED = -0.6
+        public const val IDLE_SPEED = 0.0
+        public const val HOLD_SPEED = 0.1
     }
 
     object HardwarePorts {

--- a/src/main/kotlin/org/team5499/frc2019/Robot.kt
+++ b/src/main/kotlin/org/team5499/frc2019/Robot.kt
@@ -2,6 +2,7 @@ package org.team5499.frc2019
 
 import edu.wpi.first.wpilibj.TimedRobot
 import edu.wpi.first.wpilibj.XboxController
+import edu.wpi.first.wpilibj.Joystick
 
 import org.team5499.monkeyLib.hardware.LazyTalonSRX
 import org.team5499.monkeyLib.hardware.LazyVictorSPX
@@ -20,14 +21,15 @@ import org.team5499.frc2019.input.ControlBoard
 import org.team5499.frc2019.input.IDriverControls
 import org.team5499.frc2019.input.ICodriverControls
 import org.team5499.frc2019.input.XboxDriver
-import org.team5499.frc2019.input.XboxCodriver
+import org.team5499.frc2019.input.ButtonBoardCodriver
 
 import com.ctre.phoenix.sensors.PigeonIMU
 
 class Robot : TimedRobot(Constants.ROBOT_UPDATE_PERIOD) {
     // inputs
     private val mDriver: XboxController
-    private val mCodriver: XboxController
+    private val mCodriverButtonBoard: Joystick
+    private val mCodriverJoystick: Joystick
 
     private val mSpaceDriveHelper: SpaceDriveHelper
 
@@ -65,10 +67,11 @@ class Robot : TimedRobot(Constants.ROBOT_UPDATE_PERIOD) {
     init {
         // inputs init
         mDriver = XboxController(Constants.Input.DRIVER_PORT)
-        mCodriver = XboxController(Constants.Input.CODRIVER_PORT)
+        mCodriverButtonBoard = Joystick(Constants.Input.CODRIVER_BUTTON_BOARD_PORT)
+        mCodriverJoystick = Joystick(Constants.Input.CODRIVER_JOYSTICK_PORT)
 
         mDriverControls = XboxDriver(mDriver)
-        mCodriverControls = XboxCodriver(mCodriver)
+        mCodriverControls = ButtonBoardCodriver(mCodriverButtonBoard, mCodriverJoystick)
         mControlBoard = ControlBoard(mDriverControls, mCodriverControls)
 
         mSpaceDriveHelper = SpaceDriveHelper(Constants.Input.JOYSTICK_DEADBAND, Constants.Input.TURN_MULT)

--- a/src/main/kotlin/org/team5499/frc2019/Robot.kt
+++ b/src/main/kotlin/org/team5499/frc2019/Robot.kt
@@ -94,6 +94,22 @@ class Robot : TimedRobot(Constants.ROBOT_UPDATE_PERIOD) {
 
         mIntakeTalon = LazyTalonSRX(Constants.HardwarePorts.INTAKE)
 
+        // reset hardware
+        mLeftMaster.configFactoryDefault()
+        mLeftSlave1.configFactoryDefault()
+        mLeftSlave2.configFactoryDefault()
+
+        mRightMaster.configFactoryDefault()
+        mRightSlave1.configFactoryDefault()
+        mRightSlave2.configFactoryDefault()
+
+        mGyro.configFactoryDefault()
+
+        mLiftMaster.configFactoryDefault()
+        mLiftSlave.configFactoryDefault()
+
+        mIntakeTalon.configFactoryDefault()
+
         // subsystem init
         mDrivetrain = Drivetrain(
             mLeftMaster, mLeftSlave1, mLeftSlave2,

--- a/src/main/kotlin/org/team5499/frc2019/Robot.kt
+++ b/src/main/kotlin/org/team5499/frc2019/Robot.kt
@@ -51,6 +51,8 @@ class Robot : TimedRobot(Constants.ROBOT_UPDATE_PERIOD) {
     private val mLiftMaster: LazyTalonSRX
     private val mLiftSlave: LazyTalonSRX
 
+    private val mIntakeTalon: LazyTalonSRX
+
     // subsystems
     private val mDrivetrain: Drivetrain
     private val mLift: Lift
@@ -90,6 +92,8 @@ class Robot : TimedRobot(Constants.ROBOT_UPDATE_PERIOD) {
         mLiftMaster = LazyTalonSRX(Constants.HardwarePorts.LIFT_MASTER)
         mLiftSlave = LazyTalonSRX(Constants.HardwarePorts.LIFT_SLAVE)
 
+        mIntakeTalon = LazyTalonSRX(Constants.HardwarePorts.INTAKE)
+
         // subsystem init
         mDrivetrain = Drivetrain(
             mLeftMaster, mLeftSlave1, mLeftSlave2,
@@ -97,7 +101,7 @@ class Robot : TimedRobot(Constants.ROBOT_UPDATE_PERIOD) {
             mGyro
         )
         mLift = Lift(mLiftMaster, mLiftSlave)
-        mIntake = Intake()
+        mIntake = Intake(mIntakeTalon)
         mVision = Vision()
         mWrist = Wrist()
         mSubsystemsManager = SubsystemsManager(mDrivetrain, mLift, mIntake, mVision, mWrist)

--- a/src/main/kotlin/org/team5499/frc2019/controllers/TeleopController.kt
+++ b/src/main/kotlin/org/team5499/frc2019/controllers/TeleopController.kt
@@ -2,7 +2,6 @@ package org.team5499.frc2019.controllers
 
 import org.team5499.frc2019.subsystems.SubsystemsManager
 import org.team5499.frc2019.input.ControlBoard
-import org.team5499.frc2019.subsystems.Intake.IntakeMode
 
 import org.team5499.monkeyLib.Controller
 import org.team5499.monkeyLib.input.DriveHelper
@@ -39,11 +38,11 @@ public class TeleopController(
         mSubsystems.drivetrain.setPercent(driveSignal)
 
         if (mControlBoard.codriverControls.getExaust()) {
-            mSubsystems.intake.setDesiredIntakeMode(IntakeMode.OUTTAKE)
+            mSubsystems.intake.outtake()
         } else if (mControlBoard.codriverControls.getIntake()) {
-            mSubsystems.intake.setDesiredIntakeMode(IntakeMode.INTAKE)
+            mSubsystems.intake.intake()
         } else {
-            mSubsystems.intake.setDesiredIntakeMode(IntakeMode.IDLE)
+            mSubsystems.intake.idle()
         }
     }
 

--- a/src/main/kotlin/org/team5499/frc2019/controllers/TeleopController.kt
+++ b/src/main/kotlin/org/team5499/frc2019/controllers/TeleopController.kt
@@ -2,6 +2,7 @@ package org.team5499.frc2019.controllers
 
 import org.team5499.frc2019.subsystems.SubsystemsManager
 import org.team5499.frc2019.input.ControlBoard
+import org.team5499.frc2019.subsystems.Intake.IntakeMode
 
 import org.team5499.monkeyLib.Controller
 import org.team5499.monkeyLib.input.DriveHelper
@@ -36,6 +37,14 @@ public class TeleopController(
             mControlBoard.driverControls.getQuickTurn()
         )
         mSubsystems.drivetrain.setPercent(driveSignal)
+
+        if (mControlBoard.codriverControls.getIntake()) {
+            mSubsystems.intake.setDesiredIntakeMode(IntakeMode.INTAKE)
+        } else if (mControlBoard.codriverControls.getExaust()) {
+            mSubsystems.intake.setDesiredIntakeMode(IntakeMode.OUTTAKE)
+        } else {
+            mSubsystems.intake.setDesiredIntakeMode(IntakeMode.IDLE)
+        }
     }
 
     public override fun reset() {}

--- a/src/main/kotlin/org/team5499/frc2019/controllers/TeleopController.kt
+++ b/src/main/kotlin/org/team5499/frc2019/controllers/TeleopController.kt
@@ -38,10 +38,10 @@ public class TeleopController(
         )
         mSubsystems.drivetrain.setPercent(driveSignal)
 
-        if (mControlBoard.codriverControls.getIntake()) {
-            mSubsystems.intake.setDesiredIntakeMode(IntakeMode.INTAKE)
-        } else if (mControlBoard.codriverControls.getExaust()) {
+        if (mControlBoard.codriverControls.getExaust()) {
             mSubsystems.intake.setDesiredIntakeMode(IntakeMode.OUTTAKE)
+        } else if (mControlBoard.codriverControls.getIntake()) {
+            mSubsystems.intake.setDesiredIntakeMode(IntakeMode.INTAKE)
         } else {
             mSubsystems.intake.setDesiredIntakeMode(IntakeMode.IDLE)
         }

--- a/src/main/kotlin/org/team5499/frc2019/input/ButtonBoardCodriver.kt
+++ b/src/main/kotlin/org/team5499/frc2019/input/ButtonBoardCodriver.kt
@@ -39,10 +39,10 @@ public class ButtonBoardCodriver(buttonBoard: Joystick, joystick: Joystick) : IC
     public override fun getBallHigh() = mButtonBoard.getRawButtonPressed(10)
 
     @Suppress("MagicNumber")
-    public override fun getIntake() = mButtonBoard.getRawButtonPressed(2)
+    public override fun getIntake() = mButtonBoard.getRawButton(2)
 
     @Suppress("MagicNumber")
-    public override fun getExaust() = mButtonBoard.getRawButtonPressed(0)
+    public override fun getExaust() = mButtonBoard.getRawButton(0)
 
     @Suppress("MagicNumber")
     public override fun getPickup() = mButtonBoard.getRawButtonPressed(3)

--- a/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
+++ b/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
@@ -12,7 +12,7 @@ import org.team5499.frc2019.Constants
 public class Intake : Subsystem() {
 
     companion object {
-        private const val kBallDetectionThreshold =  // amps
+        private const val kBallDetectionThreshold = 12 // amps
     }
 
     public enum class IntakeMode(val percent: Double) {
@@ -42,22 +42,22 @@ public class Intake : Subsystem() {
     }
 
     public override fun update() {
-        when (mMode) {
-            IntakeMode.INTAKE -> {
-                // if(mTalon.getOutputCurrent())
-            }
-            IntakeMode.OUTTAKE -> {}
-            IntakeMode.HOLD -> {
-                if (!ballInIntake) {
-                    mMode = IntakeMode.IDLE
-                }
-            }
-            IntakeMode.IDLE -> {
-                if (ballInIntake) {
-                    mMode = IntakeMode.HOLD
-                }
-            }
-        }
+        // when (mMode) {
+        //     IntakeMode.INTAKE -> {
+        //         // if(mTalon.getOutputCurrent())
+        //     }
+        //     IntakeMode.OUTTAKE -> {}
+        //     IntakeMode.HOLD -> {
+        //         if (!ballInIntake) {
+        //             mMode = IntakeMode.IDLE
+        //         }
+        //     }
+        //     IntakeMode.IDLE -> {
+        //         if (ballInIntake) {
+        //             mMode = IntakeMode.HOLD
+        //         }
+        //     }
+        // }
         mTalon.set(ControlMode.PercentOutput, mMode.percent)
     }
 

--- a/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
+++ b/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
@@ -9,7 +9,7 @@ import com.ctre.phoenix.motorcontrol.NeutralMode
 
 import org.team5499.frc2019.Constants
 
-public class Intake : Subsystem() {
+public class Intake(talon: LazyTalonSRX) : Subsystem() {
 
     companion object {
         private const val kBallDetectionThreshold = 12 // amps
@@ -30,34 +30,36 @@ public class Intake : Subsystem() {
         get() = mTalon.getOutputCurrent() > kBallDetectionThreshold
 
     init {
-        mTalon = LazyTalonSRX(Constants.HardwarePorts.INTAKE_MASTER)
+        mTalon = talon
         mTalon.configSelectedFeedbackSensor(FeedbackDevice.Analog)
         mTalon.setNeutralMode(NeutralMode.Coast)
 
         mMode = IntakeMode.IDLE
     }
 
-    public fun setDesiredIntakeMode(desiredMode: IntakeMode) {
-        mMode = desiredMode
+    public fun intake() {
+        mMode = IntakeMode.INTAKE
+    }
+
+    public fun outtake() {
+        mMode = IntakeMode.OUTTAKE
+    }
+
+    public fun idle() {
+        mMode = IntakeMode.IDLE
+    }
+
+    public fun hold() {
+        mMode = IntakeMode.HOLD
     }
 
     public override fun update() {
-        // when (mMode) {
-        //     IntakeMode.INTAKE -> {
-        //         // if(mTalon.getOutputCurrent())
-        //     }
-        //     IntakeMode.OUTTAKE -> {}
-        //     IntakeMode.HOLD -> {
-        //         if (!ballInIntake) {
-        //             mMode = IntakeMode.IDLE
-        //         }
-        //     }
-        //     IntakeMode.IDLE -> {
-        //         if (ballInIntake) {
-        //             mMode = IntakeMode.HOLD
-        //         }
-        //     }
-        // }
+        when (mMode) {
+            IntakeMode.INTAKE -> {}
+            IntakeMode.OUTTAKE -> {}
+            IntakeMode.HOLD -> {}
+            IntakeMode.IDLE -> {}
+        }
         mTalon.set(ControlMode.PercentOutput, mMode.percent)
     }
 

--- a/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
+++ b/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
@@ -12,7 +12,7 @@ import org.team5499.frc2019.Constants
 public class Intake : Subsystem() {
 
     companion object {
-        private const val kBallDetectionThreshold = 512 // analog tickss
+        private const val kBallDetectionThreshold =  // amps
     }
 
     public enum class IntakeMode(val percent: Double) {
@@ -26,11 +26,8 @@ public class Intake : Subsystem() {
 
     private var mMode: IntakeMode
 
-    public val ballDistanceRaw: Int
-        get() = mTalon.getSelectedSensorPosition()
-
     public val ballInIntake: Boolean
-        get() = ballDistanceRaw < kBallDetectionThreshold
+        get() = mTalon.getOutputCurrent() > kBallDetectionThreshold
 
     init {
         mTalon = LazyTalonSRX(Constants.HardwarePorts.INTAKE_MASTER)
@@ -47,15 +44,9 @@ public class Intake : Subsystem() {
     public override fun update() {
         when (mMode) {
             IntakeMode.INTAKE -> {
-                if (ballInIntake) {
-                    mMode = IntakeMode.HOLD
-                }
+                // if(mTalon.getOutputCurrent())
             }
-            IntakeMode.OUTTAKE -> {
-                if (!ballInIntake) {
-                    mMode = IntakeMode.IDLE
-                }
-            }
+            IntakeMode.OUTTAKE -> {}
             IntakeMode.HOLD -> {
                 if (!ballInIntake) {
                     mMode = IntakeMode.IDLE

--- a/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
+++ b/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
@@ -3,22 +3,78 @@ package org.team5499.frc2019.subsystems
 import org.team5499.monkeyLib.Subsystem
 import org.team5499.monkeyLib.hardware.LazyTalonSRX
 
+import com.ctre.phoenix.motorcontrol.FeedbackDevice
+import com.ctre.phoenix.motorcontrol.ControlMode
+import com.ctre.phoenix.motorcontrol.NeutralMode
+
 import org.team5499.frc2019.Constants
 
 public class Intake : Subsystem() {
 
-    private val mPlaceHolderTalon: LazyTalonSRX
+    companion object {
+        private const val kBallDetectionThreshold = 512 // analog tickss
+    }
+
+    public enum class IntakeMode(val percent: Double) {
+        INTAKE(Constants.Intake.INTAKE_SPEED),
+        HOLD(Constants.Intake.HOLD_SPEED),
+        OUTTAKE(Constants.Intake.OUTTAKE_SPEED),
+        IDLE(Constants.Intake.IDLE_SPEED)
+    }
+
+    private val mTalon: LazyTalonSRX
+
+    private var mMode: IntakeMode
+
+    public val ballDistanceRaw: Int
+        get() = mTalon.getSelectedSensorPosition()
+
+    public val ballInIntake: Boolean
+        get() = ballDistanceRaw < kBallDetectionThreshold
 
     init {
-        mPlaceHolderTalon = LazyTalonSRX(Constants.HardwarePorts.INTAKE_MASTER)
+        mTalon = LazyTalonSRX(Constants.HardwarePorts.INTAKE_MASTER)
+        mTalon.configSelectedFeedbackSensor(FeedbackDevice.Analog)
+        mTalon.setNeutralMode(NeutralMode.Coast)
+
+        mMode = IntakeMode.IDLE
+    }
+
+    public fun setDesiredIntakeMode(desiredMode: IntakeMode) {
+        mMode = desiredMode
     }
 
     public override fun update() {
+        when (mMode) {
+            IntakeMode.INTAKE -> {
+                if (ballInIntake) {
+                    mMode = IntakeMode.HOLD
+                }
+            }
+            IntakeMode.OUTTAKE -> {
+                if (!ballInIntake) {
+                    mMode = IntakeMode.IDLE
+                }
+            }
+            IntakeMode.HOLD -> {
+                if (!ballInIntake) {
+                    mMode = IntakeMode.IDLE
+                }
+            }
+            IntakeMode.IDLE -> {
+                if (ballInIntake) {
+                    mMode = IntakeMode.HOLD
+                }
+            }
+        }
+        mTalon.set(ControlMode.PercentOutput, mMode.percent)
     }
 
     public override fun stop() {
+        mTalon.set(ControlMode.PercentOutput, 0.0)
+        mTalon.neutralOutput()
+        mMode = IntakeMode.IDLE
     }
 
-    public override fun reset() {
-    }
+    public override fun reset() {}
 }

--- a/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
+++ b/src/main/kotlin/org/team5499/frc2019/subsystems/Intake.kt
@@ -55,7 +55,11 @@ public class Intake(talon: LazyTalonSRX) : Subsystem() {
 
     public override fun update() {
         when (mMode) {
-            IntakeMode.INTAKE -> {}
+            IntakeMode.INTAKE -> {
+                if (ballInIntake) {
+                    mMode = IntakeMode.HOLD
+                }
+            }
             IntakeMode.OUTTAKE -> {}
             IntakeMode.HOLD -> {}
             IntakeMode.IDLE -> {}
@@ -69,5 +73,7 @@ public class Intake(talon: LazyTalonSRX) : Subsystem() {
         mMode = IntakeMode.IDLE
     }
 
-    public override fun reset() {}
+    public override fun reset() {
+        stop()
+    }
 }


### PR DESCRIPTION
Makes sure that the talons do not have any weird settings configured when the robot is turned on. All the settings are set in the constructors of the subsystems.